### PR TITLE
chore: update deprecated methods and kwargs for ruby 3

### DIFF
--- a/lib/to_lang/connector.rb
+++ b/lib/to_lang/connector.rb
@@ -19,7 +19,7 @@ module ToLang
         if value.nil?
           key
         elsif value.is_a?(Array)
-          value.map {|v| "#{key}=#{URI.encode(v.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}"}
+          value.map {|v| "#{key}=#{URI::Parser.new.escape(v.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}"}
         else
           {key => value}.to_params
         end

--- a/lib/to_lang/core_ext.rb
+++ b/lib/to_lang/core_ext.rb
@@ -31,7 +31,7 @@ class Hash
     elsif value.is_a?(Hash)
       stack << [key,value]
     else
-      param << "#{key}=#{URI.encode(value.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}&"
+      param << "#{key}=#{URI::Parser.new.escape(value.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}&"
     end
 
     stack.each do |parent, hash|

--- a/lib/to_lang/translatable.rb
+++ b/lib/to_lang/translatable.rb
@@ -12,8 +12,8 @@ module ToLang
     #
     # @return [String] The translated string.
     #
-    def translate(target, *args)
-      ToLang.connector.request(self, target, *args)
+    def translate(target, *args, **kwargs)
+      ToLang.connector.request(self, target, *args, **kwargs)
     end
 
     # Chain @method_missing@ in case another library has used it.
@@ -24,28 +24,28 @@ module ToLang
     #
     # @private
     #
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, **kwargs, &block)
       case method.to_s
       when /^to_(.*)_from_(.*)$/
         if CODEMAP[$1] && CODEMAP[$2]
           define_and_call_method(method) { translate(CODEMAP[$1], :from => CODEMAP[$2]) }
         else
-          original_method_missing(method, *args, &block)
+          original_method_missing(method, *args, **kwargs, &block)
         end
       when /^from_(.*)_to_(.*)$/
         if CODEMAP[$1] && CODEMAP[$2]
           define_and_call_method(method) { translate(CODEMAP[$2], :from => CODEMAP[$1]) }
         else
-          original_method_missing(method, *args, &block)
+          original_method_missing(method, *args, **kwargs, &block)
         end
       when /^to_(.*)$/
         if CODEMAP[$1]
           define_and_call_method(method) { translate(CODEMAP[$1]) }
         else
-          original_method_missing(method, *args, &block)
+          original_method_missing(method, *args, **kwargs, &block)
         end
       else
-        original_method_missing(method, *args, &block)
+        original_method_missing(method, *args, **kwargs, &block)
       end
     end
 


### PR DESCRIPTION
Update for compatibility with Ruby 3:
- replace the deprecated `URI.encode` method with `URI::Parser.new.escape`
- separate positional and keyword arguments (https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)